### PR TITLE
Make the docs consistent with data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,33 +44,22 @@ territories/
 │       ├── keys.json
 │       ├── previews.json
 │       ├── AD/
-│       │   ├── data.json
-│       │   ├── AD-07/
-│       │   │   └── data.json
-│       │   ├── AD-02/
-│       │   │   └── data.json
-│       │   ...
+│       │   ├── keys.json
+│       │   └── previews.json
 │       │   
 │       ├── AE/
 │       │   ├── keys.json
-│       │   ├── AE-AZ/
-│       │   │   └── data.json
-│       │   ├── AE-AJ/
-│       │   │   └── data.json
-│       │   ...
+│       │   └── previews.json
 │       │   
 │       ├── AD/
-│       │   ├── data.json
-│       │   ├── AF-BDS/
-│       │   │   └── data.json
-│       │   ├── AF-BDG/
-│       │   │   └── data.json
+│       │   ├── keys.json
+│       │   └── previews.json
 │       │   ...
 │       ...   
 ...
 ```
 
-The root `keys.json` file in the `data` folder contains an array of all country [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) codes, if you want to just get a list of all countries. 
+The root `keys.json` file in the `json` folder contains an array of all country [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) codes, if you want to just get a list of all countries. 
 
 For example: 
 
@@ -111,7 +100,7 @@ For example:
 ]
 ```
 
-Each of the keys bove also has a namesake folder in the root `data` folder. Each of these have their own `keys.json` and `preview.json` files following the same structure. Note that _subdivision_ is the umbrella term used by the ISO 3166-2 for the highest territorial unit under country. This can be states, provinces, districts, prefectures, _et al._
+Each of the keys above also has a namesake folder in the root `json` folder. Each of these have their own `keys.json` and `preview.json` files following the same structure. Note that _subdivision_ is the umbrella term used by the ISO 3166-2 for the highest territorial unit under country. This can be states, provinces, districts, prefectures, _et al._
 
 For example [AD/keys.json](https://github.com/schalkventer/territories/blob/master/packages/json/AD/keys.json): 
 

--- a/README.md
+++ b/README.md
@@ -38,103 +38,111 @@
 
 ```
 territories/
-├── data/
-│   ├── keys.json
-│   ├── previews.json
-│   ├── AD/
-│   │   ├── data.json
-│   │   ├── AD-07/
-│   │   │   └── data.json
-│   │   ├── AD-02/
-│   │   │   └── data.json
-│   │   ...
-│   │   
-│   ├── AE/
-│   │   ├── keys.json
-│   │   ├── AE-AZ/
-│   │   │   └── data.json
-│   │   ├── AE-AJ/
-│   │   │   └── data.json
-│   │   ...
-│   │   
-│   ├── AD/
-│   │   ├── data.json
-│   │   ├── AF-BDS/
-│   │   │   └── data.json
-│   │   ├── AF-BDG/
-│   │   │   └── data.json
-│   │   ...
-│   │   
+├── packages/
+|   └── json/
+│       ├── keys.json
+│       ├── previews.json
+│       ├── AD/
+│       │   ├── data.json
+│       │   ├── AD-07/
+│       │   │   └── data.json
+│       │   ├── AD-02/
+│       │   │   └── data.json
+│       │   ...
+│       │   
+│       ├── AE/
+│       │   ├── keys.json
+│       │   ├── AE-AZ/
+│       │   │   └── data.json
+│       │   ├── AE-AJ/
+│       │   │   └── data.json
+│       │   ...
+│       │   
+│       ├── AD/
+│       │   ├── data.json
+│       │   ├── AF-BDS/
+│       │   │   └── data.json
+│       │   ├── AF-BDG/
+│       │   │   └── data.json
+│       │   ...
+│       ...   
 ...
 ```
 
-The root `keys.json` file in the `data` folder contains an array of all country [ISO 3166-2 coes](https://en.wikipedia.org/wiki/ISO_3166-2) codes if you want to just get a list of all countries. For example: 
+The root `keys.json` file in the `data` folder contains an array of all country [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) codes, if you want to just get a list of all countries. 
 
-```
+For example: 
+
+```json5
 [
   "AD",
   "AE",
   "AF",
-  ...
+  // ...
 ]
 ```
 
-However, you probably require a bit more than just the ISO 3166-2 key if you want to surface this information in your user interface. Luckily there is also a previews.json file with a bit more information
+However, you probably require a bit more than just the ISO 3166-2 key if you want to surface this information in your user interface. Luckily there is also a `previews.json` file with a bit more information. 
 
-```
+For example:
+
+```json5
 [
   {
-    key: "AD",
-    name: "Andorra",
-    icon: "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/ad.svg",
-  }, 
-  {
-    key: "AE",
-    name: "United Arab Emirates",
-    icon: "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/ae.svg",
+    "key": "AD",
+    "icon": "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/ad.svg",
+    "name": "Andorra",
+    "link": "https://en.wikipedia.org//wiki/ISO_3166-2:AD"
   },
   {
-    key: "AF",
-    name: "Afghanistan",
-    icon: "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/af.svg",
+    "key": "AE",
+    "icon": "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/ae.svg",
+    "name": "United Arab Emirates",
+    "link": "https://en.wikipedia.org//wiki/ISO_3166-2:AE"
   },
-  ...
+  {
+    "key": "AF",
+    "icon": "https://cdn.rawgit.com/hjnilsson/country-flags/master/svg/af.svg",
+    "name": "Afghanistan",
+    "link": "https://en.wikipedia.org//wiki/ISO_3166-2:AF"
+  },
+  // ...
 ]
 ```
 
 Each of the keys bove also has a namesake folder in the root `data` folder. Each of these have their own `keys.json` and `preview.json` files following the same structure. Note that _subdivision_ is the umbrella term used by the ISO 3166-2 for the highest territorial unit under country. This can be states, provinces, districts, prefectures, _et al._
 
-For example `AD/keys.json`: 
+For example [AD/keys.json](https://github.com/schalkventer/territories/blob/master/packages/json/AD/keys.json): 
 
-```
+```json5
 [
   "AD-07",
   "AE-02",
   "AF-03",
-  ...
+  // ...
 ]
 ```
 
-And also `AD/previews.json`
+And also [AD/previews.json](https://github.com/schalkventer/territories/blob/master/packages/json/AD/previews.json):
 
-```
+```json5
 [
   {
-    key: "AD-07",
-    name: "Andorra la Vella",
-    icon: "https://upload.wikimedia.org/wikipedia/commons/a/a4/Escut_d%27Andorra_la_Vella.svg",
+    "key": "AD-07",
+    "name": "Andorra la Vella",
+    "icon": "https:////upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Escut_d%27Andorra_la_Vella.svg/23px-Escut_d%27Andorra_la_Vella.svg.png"
   },
   {
-    key: "AE-02",
-    name: "Canillo",
-    icon: "https://en.wikipedia.org/wiki/File:Escut_de_Canillo.svg",
+    "key": "AD-02",
+    "name": "Canillo",
+    "icon": "https:////upload.wikimedia.org/wikipedia/commons/thumb/4/4b/Escut_de_Canillo.svg/23px-Escut_de_Canillo.svg.png"
   },
   {
-    key: "AF-03",
-    name: "Encamp",
-    icon: "https://en.wikipedia.org/wiki/File:Escut_d%27Encamp.svg",
+    "key": "AD-03",
+    "name": "Encamp",
+    "icon": "https:////upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Escut_d%27Encamp.svg/23px-Escut_d%27Encamp.svg.png"
   },
-  ...
+  // ...
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 🗺 Territories
+> A JSON catalogue of countries, cities and everything inbetween, as well as UI to consume the data
 
 ## Example
 


### PR DESCRIPTION
I've used `json5` for highlighting JSON, as it supports `// comments` without making them red as invalid.